### PR TITLE
Fixes (field name length, unicode chars)

### DIFF
--- a/src/lib.js
+++ b/src/lib.js
@@ -18,6 +18,13 @@ module.exports.rpad = function rpad(str, len, char) {
     while (str.length < len) { str = str + char; } return str;
 };
 
+module.exports.rpadbuf = function rpad(buf, len, char) {
+  var buffer = Buffer.alloc(len, char);
+  buf.copy(buffer);
+  return buffer;
+};
+
+
 /**
  * @param {object} view
  * @param {number} fieldLength
@@ -25,9 +32,10 @@ module.exports.rpad = function rpad(str, len, char) {
  * @param {number} offset
  * @returns {number}
  */
-module.exports.writeField = function writeField(view, fieldLength, str, offset) {
-    for (var i = 0; i < fieldLength; i++) {
-        view.setUint8(offset, str.charCodeAt(i)); offset++;
-    }
-    return offset;
+module.exports.writeField = function writeField(view, fieldLength, buf, offset) {
+  for (var i = 0; i < fieldLength; i++) {
+    view.setUint8(offset, buf[i]);
+    offset++;
+  };
+  return offset;
 };

--- a/src/structure.js
+++ b/src/structure.js
@@ -45,7 +45,7 @@ module.exports = function structure(data, meta) {
 
     field_meta.forEach(function(f, i) {
         // field name
-        f.name.split('').slice(0, 8).forEach(function(c, x) {
+        f.name.split('').slice(0, 9).forEach(function(c, x) {
             view.setInt8(32 + i * 32 + x, c.charCodeAt(0));
         });
         // field type
@@ -75,20 +75,20 @@ module.exports = function structure(data, meta) {
                 // date
                 case 'D':
                     offset = lib.writeField(view, 8,
-                        lib.lpad(val.toString(), 8, ' '), offset);
+                        Buffer.from(lib.lpad(val.toString(), 8, ' ')), offset);
                     break;
 
                 // number
                 case 'N':
                     offset = lib.writeField(view, f.size,
-                        lib.lpad(val.toString(), f.size, ' ').substr(0, 18),
+                        Buffer.from(lib.lpad(val.toString(), f.size, ' ')),
                         offset);
                     break;
 
                 // string
                 case 'C':
                     offset = lib.writeField(view, f.size,
-                        lib.rpad(val.toString(), f.size, ' '), offset);
+                        lib.rpadbuf(val, f.size, ' '), offset);
                     break;
 
                 default:


### PR DESCRIPTION
1. fix field name length bug.
2. fix bug with unicode characters, it needs to save as is from buffer, without .toString()