### PR TITLE
Update structure.js

### DIFF
--- a/src/structure.js
+++ b/src/structure.js
@@ -55,7 +55,7 @@ module.exports = function structure(data, meta) {
         if (f.type == 'N') view.setInt8(32 + i * 32 + 17, 3);
     });
 
-    offset = fieldDescLength + 32;
+    var offset = fieldDescLength + 32;
 
     data.forEach(function(row, num) {
         // delete flag: this is not deleted


### PR DESCRIPTION
i'm get the error 'offset' is not defined because i use strict mode.
so the fix for this kind of issue is to change

in dbf/src/structure.js

(line number 58)
from:

offset = fieldDescLength + 32;

to:

var offset = fieldDescLength + 32;