### PR TITLE
Increase field name length from 8 to 10 characters.

### DIFF
--- a/src/structure.js
+++ b/src/structure.js
@@ -45,7 +45,7 @@ module.exports = function structure(data, meta) {
 
     field_meta.forEach(function(f, i) {
         // field name
-        f.name.split('').slice(0, 8).forEach(function(c, x) {
+        f.name.split('').slice(0, 10).forEach(function(c, x) {
             view.setInt8(32 + i * 32 + x, c.charCodeAt(0));
         });
         // field type


### PR DESCRIPTION
Shapefile specifies a maximum field name length of 10 characters.

https://en.wikipedia.org/wiki/Shapefile#Data_storage